### PR TITLE
daemon/cupslocald-systemd.service.in: add system-cups.slice

### DIFF
--- a/daemon/cupslocald-systemd.service.in
+++ b/daemon/cupslocald-systemd.service.in
@@ -5,3 +5,4 @@ Description=CUPS Local Spooler
 Type=dbus
 BusName=org.openprinting.cups-locald
 ExecStart=@sbindir@/cups-locald
+Slice=system-cups.slice


### PR DESCRIPTION
See https://github.com/OpenPrinting/cups/pull/1035 for rationale and an explanation.

The ``system-cups.slice`` file included in the aforementioned PR is not required; the ``system-cups`` slice will be automatically created if the file is missing.